### PR TITLE
include single quotation marks for character

### DIFF
--- a/project1/test/test_1_r01.out
+++ b/project1/test/test_1_r01.out
@@ -29,7 +29,7 @@ Program (1)
                 ID: c
               ASSIGN
               Exp (3)
-                CHAR: c
+                CHAR: 'c'
             SEMI
           StmtList (4)
             Stmt (4)

--- a/project1/test/test_1_r12.out
+++ b/project1/test/test_1_r12.out
@@ -43,7 +43,7 @@ Program (1)
                       ID: ch
                     ASSIGN
                     Exp (5)
-                      CHAR: \xC0
+                      CHAR: '\xC0'
                 SEMI
         StmtList (6)
           Stmt (6)


### PR DESCRIPTION
From the email sent by <wangsn@mail.sustech.edu.cn>

> To output the character literal 'c', the single quotation marks should be included. In other word, the GitHub sample output is wrong, please follow the project documentation.
